### PR TITLE
allow PR permissions and change rulesets for GitHub Actions

### DIFF
--- a/.github/workflows/update-starlink-tle.yml
+++ b/.github/workflows/update-starlink-tle.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     
     permissions:
-      contents: write  # Required to commit changes
+      contents: write      
+      pull-requests: write 
+      issues: write  
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Needs update to allow main branch to accept github actions bots to make PRs on its own. Current workflow gets denied